### PR TITLE
chore: improve closer

### DIFF
--- a/pkg/utils/collections.go
+++ b/pkg/utils/collections.go
@@ -14,6 +14,27 @@ func Map[T, U any](arr []T, f func(x T) U) []U {
 	return result
 }
 
+// MapWithError maps the array to another array
+// with elements that were converted by provided function.
+// If the provided function returns an error,
+// MapWithError returns nil array and this error as a result.
+//
+// Example: Map([1, 2, 3], f(x) -> x*2) -> [2, 4, 6]
+func MapWithError[T, U any](arr []T, f func(x T) (U, error)) ([]U, error) {
+	result := make([]U, 0, len(arr))
+
+	for _, x := range arr {
+		mapped, err := f(x)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, mapped)
+	}
+
+	return result, nil
+}
+
 // GroupBy groups the array by result of provided function.
 // The value by key contains ALL elements of the array
 // where the key is equal to the result of the provided function.

--- a/pkg/utils/collections_test.go
+++ b/pkg/utils/collections_test.go
@@ -3,10 +3,12 @@ package utils_test
 import (
 	"reflect"
 	"slices"
+	"strconv"
 	"testing"
 
 	"github.com/bogi-lyceya-44/common/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMap(t *testing.T) {
@@ -23,6 +25,46 @@ func TestMap(t *testing.T) {
 	)
 
 	assert.Equal(t, expected, got)
+}
+
+func TestMapWithError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		have    []string
+		want    []int
+		wantErr bool
+	}{
+		{
+			name:    "correct strings",
+			have:    []string{"1", "2", "3"},
+			want:    []int{1, 2, 3},
+			wantErr: false,
+		},
+		{
+			name:    "incorrect strings",
+			have:    []string{"1", "asdfasdf", "aaa"},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				got, err := utils.MapWithError(tt.have, strconv.Atoi)
+				if err != nil {
+					require.True(t, tt.wantErr)
+				}
+
+				require.Equal(t, tt.want, got)
+			},
+		)
+	}
 }
 
 func TestGroupBy(t *testing.T) {


### PR DESCRIPTION
Можно вместо того чтоб ждать глобальный контекст <-ctx, ждать closer.Wait(), который еще и вернет ошибку если что то пошло не так при выполнении колбеков